### PR TITLE
When universal items installed, allow arbitrary items

### DIFF
--- a/src/custom_pins/changelog.json
+++ b/src/custom_pins/changelog.json
@@ -1,4 +1,5 @@
 {
+    "1.2.0": ["Universal Items support (by emanresu)"],
     "1.1.0": [
         "Partial compatibility with shapez Industries",
         "Customizable keyboard shortcut"

--- a/src/custom_pins/index.js
+++ b/src/custom_pins/index.js
@@ -9,7 +9,8 @@ import {
     pinNewShape,
     postRerenderFull,
     serialize,
-    unpinShape
+    unpinShape,
+    isUniversalItemsPresent
 } from "./logic";
 import { HUDGameMenu } from "game/hud/parts/game_menu";
 import { makeDivElement } from "core/utils";
@@ -47,7 +48,7 @@ function pinNewCustomShape() {
         id: "customShapeKey",
         label: "Or enter short key of the shape you want to pin:",
         placeholder: "",
-        validator: ShapeDefinition.isValidShortKey
+        validator: isUniversalItemsPresent() ? this.root.parseShortCode : ShapeDefinition.isValidShortKey
     });
 
     const useThroughput = new FormElementCheckbox({
@@ -64,12 +65,12 @@ function pinNewCustomShape() {
         buttons: ["cancel:bad:escape", "ok:good:enter"],
         closeButton: false
     });
-
-    const closeHandler = (shape) => {
+    // Note: If Universal Items is installed, pinNewShape can take either a definition or an item, and so can this.
+    const closeHandler = (item) => {
         const throughput = useThroughput.getValue();
 
         this.root.hud.signals.shapePinRequested.dispatch(
-            shape, // definition to pin
+            item, // definition to pin
             true, // pin as a custom shape
             throughput // display throughput
         );
@@ -87,7 +88,8 @@ function pinNewCustomShape() {
         const key = keyInput.getValue();
 
         const definitionMgr = this.root.shapeDefinitionMgr;
-        closeHandler(definitionMgr.getShapeFromShortKey(key));
+        const resolved = isUniversalItemsPresent() ? this.root.parseShortCode(key) :  definitionMgr.getShapeFromShortKey(key)
+        closeHandler(resolved);
     });
 
     this.root.hud.parts.dialogs.internalShowDialog(dialog);

--- a/src/custom_pins/logic.js
+++ b/src/custom_pins/logic.js
@@ -1,5 +1,6 @@
 import { arrayDeleteValue } from "core/utils";
 import { MODS } from "mods/modloader";
+import { ShapeDefinition } from "game/shape_definition";
 
 /**
  * Write custom pinned shapes to the savegame object.
@@ -65,7 +66,7 @@ export function postRerenderFull() {
  * @this {import("game/hud/parts/pinned_shapes").HUDPinnedShapes}
  */
 export function pinNewShape(_, args) {
-    const key = args[0].getHash();
+    const key = args[0] instanceof ShapeDefinition ? args[0].getHash() : args[0].getAsCopyableKey();
     if (this.isShapePinned(key)) {
         return;
     }
@@ -104,4 +105,8 @@ function isValidCustomPin(pin) {
 
 export function isIndustriesPresent() {
     return MODS.mods.some((mod) => mod.metadata.id === "shapez-industries");
+}
+
+export function isUniversalItemsPresent() {
+    return MODS.mods.some((mod) => mod.metadata.id === "emanresu:universal-items");
 }

--- a/src/custom_pins/logic.js
+++ b/src/custom_pins/logic.js
@@ -62,11 +62,19 @@ export function postRerenderFull() {
 }
 
 /**
- * @param {[import("game/shape_definition").ShapeDefinition, boolean?, boolean?]} args
+ * @param {[
+ *     import("game/shape_definition").ShapeDefinition | import("game/base_item").BaseItem,
+ *     boolean?,
+ *     boolean?
+ * ]} args
  * @this {import("game/hud/parts/pinned_shapes").HUDPinnedShapes}
  */
 export function pinNewShape(_, args) {
-    const key = args[0] instanceof ShapeDefinition ? args[0].getHash() : args[0].getAsCopyableKey();
+    // If Universal Items is installed, first argument is a BaseItem
+    const key =
+        args[0] instanceof ShapeDefinition
+            ? args[0].getHash()
+            : args[0].getAsCopyableKey();
     if (this.isShapePinned(key)) {
         return;
     }
@@ -108,5 +116,8 @@ export function isIndustriesPresent() {
 }
 
 export function isUniversalItemsPresent() {
-    return MODS.mods.some((mod) => mod.metadata.id === "emanresu:universal-items");
+    // TODO: Split this into environment-wide "known mods" store, like authors
+    return MODS.mods.some(
+        (mod) => mod.metadata.id === "emanresu:universal-items"
+    );
 }

--- a/src/custom_pins/mod.json
+++ b/src/custom_pins/mod.json
@@ -2,7 +2,7 @@
     "entry": "./index.js",
     "name": "Custom Pins",
     "description": "Pin any shape and track stored amount or throughput.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "doesNotAffectSavegame": true,
     "id": "custom_pins"
 }


### PR DESCRIPTION
When Universal Items is installed, this lets Custom Pins allow pinning arbitrary items.  

Prettier wasn't working so this may need reformatting, but I've tested it with industries / packaging and it works fine.